### PR TITLE
Update IMU orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Hip position and velocity limits
+- IMU orientation to be consistent with assembly instructions
 - Knee position and velocity limits
 - Wheel velocity limits
 

--- a/urdf/upkie.urdf
+++ b/urdf/upkie.urdf
@@ -126,7 +126,7 @@ And in case of doubt:
     </link>
 
     <joint name="imu_fix" type="fixed">
-        <origin rpy="3.141592653589793 0 0" xyz="0 0 0"/>  <!-- no translation -->
+        <origin rpy="3.141592653589793 0 3.141592653589793" xyz="0 0 0"/>  <!-- no translation -->
         <parent link="base" />
         <child link="imu" />
     </joint>


### PR DESCRIPTION
Update the IMU orientation to the following one:

![image](https://github.com/tasts-robots/upkie_description/assets/1189580/9bb06384-248a-4fb1-b5d6-c27f3b29b714)

It is consistent with the [head plate orientation](https://github.com/tasts-robots/upkie/wiki/6%29-Assembly#65-assemble-the-head-plate). From the Wiki:

![image](https://github.com/tasts-robots/upkie_description/assets/1189580/898699b8-e6c1-4443-99bc-d0d9052fd5f9)